### PR TITLE
Composite glyphs fail to persist curve flag

### DIFF
--- a/src/ttfParser.h
+++ b/src/ttfParser.h
@@ -956,6 +956,7 @@ int8_t TTFFontParser::parse_data(const char* data, TTFFontParser::FontData* font
 						out.p1.y = _in.p1.x * composite_glyph_element_transformation[2] + _in.p1.y * composite_glyph_element_transformation[3] + composite_glyph_element_transformation[5];
 						out.c.x = _in.c.x * composite_glyph_element_transformation[0] + _in.c.y * composite_glyph_element_transformation[1] + composite_glyph_element_transformation[4];
 						out.c.y = _in.c.x * composite_glyph_element_transformation[2] + _in.c.y * composite_glyph_element_transformation[3] + composite_glyph_element_transformation[5];
+						out.is_curve = _in.is_curve;
 						return out;
 					};
 


### PR DESCRIPTION
When a glyph is constructed of composite curves, the curves in the composite do not persist the "curve" flag.

A simple test case for this is the glyph `0xC5` in the Arial font (available [here](https://befonts.com/arial-font.html)). The glyph is made from the composite of the letter 'A' and the ring diacritic. The curve flag is not preserved on either.

Without change:
![image](https://github.com/kv01/ttf-parser/assets/123248449/b8417aa5-a89f-4843-8376-9491cdfe596d)

With change (amount of vertices on Bezier curve ≈ 20):
![image](https://github.com/kv01/ttf-parser/assets/123248449/45a1f3f5-a542-46f6-b519-65c6d4d39cf4)

I cannot provide the source code used to generate the above screenshots at this time.